### PR TITLE
add warning to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 # WorkOS React Native Expo Example App
 
+> [!CAUTION]
+> **This example application is significantly outdated and contains security vulnerabilities.** The current implementation includes dangerous practices that could expose sensitive credentials. This repository is being maintained for reference only and should not be used as a basis for production applications.
+>
+> A completely revised and secure example application is in development and will replace this version soon. Please check back for updates or refer to the [WorkOS documentation](https://workos.com/docs) for current best practices.
+
 An example React Native Expo application demonstrating to use the WorkOS API to authenticate users via SSO, pull directory user details with Directory Sync and recieve and parse Webhooks.
 
 ## Prerequisites


### PR DESCRIPTION
This pull request updates the `README.md` to warn users about security risks in the example application and clarify its deprecated status, as noted in #45. The most important change is the addition of a prominent caution notice.

Documentation and security warning:

* Added a caution block at the top of `README.md` warning that the example app is outdated, contains security vulnerabilities, and should not be used for production. It also notes that a secure replacement is in development and provides a link to current documentation.
<img width="1824" height="834" alt="capture_20250916_095915" src="https://github.com/user-attachments/assets/f3285e15-1c4e-4c17-8780-65be4c3ee160" />
